### PR TITLE
Add security context configuration to chart.

### DIFF
--- a/zeebe-cluster/templates/statefulset.yaml
+++ b/zeebe-cluster/templates/statefulset.yaml
@@ -81,6 +81,8 @@ spec:
         configMap:
           name: {{ tpl .Values.global.zeebe . | quote }}
           defaultMode: 0744
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/zeebe-cluster/values.yaml
+++ b/zeebe-cluster/values.yaml
@@ -63,3 +63,6 @@ readinessProbe:
   periodSeconds: 10
   successThreshold: 1
   timeoutSeconds: 1
+podSecurityContext:
+  fsGroup: 1000
+  runAsUser: 1000


### PR DESCRIPTION
My environment has enabled [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) and it's not recommended to run container as `root`.