### PR TITLE
Set proper default values to avoid warnings when overriding

### DIFF
--- a/zeebe-cluster/values.yaml
+++ b/zeebe-cluster/values.yaml
@@ -74,8 +74,8 @@ readinessProbe:
   successThreshold: 1
   timeoutSeconds: 1
 
-nodeSelector: 
+nodeSelector: {}
 
-tolerations: 
+tolerations: []
 
-affinity: 
+affinity: {}


### PR DESCRIPTION
We need to set proper default values for nodeSelector, tolerations and affinity. If we don't set proper default values({} or []) and you override e.g. nodeSelector you will get warnings from Helm.
e.g.
```
coalesce.go:165: warning: skipped value for nodeSelector: Not a table.
```
The end result is still correct, but it is very annoying to get warnings in the build when we create our Helm chart with overrides for these values