### PR TITLE
Standalone Gateway by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ env:
 | `gateway.replicas`         | The number of standalone gateways that should be deployed | `1`
 | `gateway.logLevel`         | The log level of the gateway, one of: ERROR, WARN, INFO, DEBUG, TRACE | `warn`
 
-
 ## Dependencies
 
 This chart currently depends on the following charts:

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ env:
 | `nodeSelector`                 | Node selection constraint to schedule Zeebe on specific nodes                                                                                                                                | {}  
 | `tolerations`                 | Tolerations to allow Zeebe to run on dedicated nodes                                                                                                                                | []  
 | `affinity`                 | Use affinity constraints to schedule Zeebe on specific nodes                                                                                                                                | {}  
+| `gateway.replicas`         | The number of standalone gateways that should be deployed | `1`
+| `gateway.logLevel`         | The log level of the gateway, one of: ERROR, WARN, INFO, DEBUG, TRACE | `warn`
+
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Zeebe Cluster Helm Chart
 
-This functionality is in beta and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.
+This functionality is in beta and is subject to change. The design and code is less mature than official GA features and is provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.
 
 ## Requirements
 
@@ -12,7 +12,7 @@ This functionality is in beta and is subject to change. The design and code is l
 
 ## Installing
 
-* Add the official zeebe helm charts repo
+* Add the official Zeebe helm charts repo
 
   ```shell
   helm repo add zeebe https://helm.zeebe.io
@@ -58,6 +58,14 @@ env:
 | `affinity`                 | Use affinity constraints to schedule Zeebe on specific nodes                                                                                                                                | {}  
 | `gateway.replicas`         | The number of standalone gateways that should be deployed | `1`
 | `gateway.logLevel`         | The log level of the gateway, one of: ERROR, WARN, INFO, DEBUG, TRACE | `warn`
+| `serviceHttpPort`         | The http port used by the brokers and the gateway| `9600`
+| `servicGatewayPort`         | The gateway port used by the gateway | `26500`
+| `serviceInternalPort`         | The internal port used by the brokers and the gateway | `26502`
+| `servicCommandPort`         | The command port used the brokers | `26501`
+| `serviceHttpName`         | The http port name used by the brokers and the gateway| `http`
+| `servicGatewayName`         | The gateway port name used by the gateway | `gateway`
+| `serviceInternalName`         | The internal port name used by the brokers and the gateway | `internal`
+| `servicCommandName`         | The command port name used the brokers | `command`
 
 ## Dependencies
 

--- a/zeebe-cluster/templates/configmap.yaml
+++ b/zeebe-cluster/templates/configmap.yaml
@@ -35,6 +35,8 @@ data:
     [threads]
     cpuThreadCount = {{ .Values.cpuThreadCount | quote }}
     ioThreadCount = {{ .Values.ioThreadCount | quote }}
+    [gateway]
+    enabled = false
     [gateway.monitoring]
     enabled = {{ .Values.gatewayMetrics | default false }}
     [[exporters]]

--- a/zeebe-cluster/templates/gateway-deployment.yaml
+++ b/zeebe-cluster/templates/gateway-deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ tpl .Values.global.zeebe . }}-gateway
+  labels:
+    app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app: {{ tpl .Values.global.zeebe . }}-gateway
+  annotations:
+      {{- range $key, $value := .Values.annotations }}
+      {{ $key }}: {{ $value | quote }}
+      {{- end }}   
+spec:
+  replicas: {{ .Values.gateway.replicas  }}
+  selector:
+    matchLabels:
+      app: {{ tpl .Values.global.zeebe . }}-gateway  
+  template:
+    metadata:  
+      labels:
+        app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app: {{ tpl .Values.global.zeebe . }}-gateway
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}-gateway
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 26500
+              name: gateway
+            - containerPort: 26502
+              name: cluster
+            - containerPort: 9600
+              name: monitoring
+          env:
+            - name: ZEEBE_STANDALONE_GATEWAY
+              value: "true"
+            - name: ZEEBE_GATEWAY_CLUSTER_MEMBER_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          readinessProbe:
+            tcpSocket:
+              port: gateway
+            initialDelaySeconds: 20
+            periodSeconds: 5

--- a/zeebe-cluster/templates/gateway-deployment.yaml
+++ b/zeebe-cluster/templates/gateway-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app: {{ tpl .Values.global.zeebe . }}-gateway
+    app: {{ printf "%s-gateway" (tpl .Values.global.zeebe .) | quote }}
   annotations:
       {{- range $key, $value := .Values.annotations }}
       {{ $key }}: {{ $value | quote }}
@@ -14,13 +14,13 @@ spec:
   replicas: {{ .Values.gateway.replicas  }}
   selector:
     matchLabels:
-      app: {{ tpl .Values.global.zeebe . }}-gateway  
+      app: {{ printf "%s-gateway" (tpl .Values.global.zeebe .) | quote }}
   template:
     metadata:  
       labels:
         app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        app: {{ tpl .Values.global.zeebe . }}-gateway
+        app: {{ printf "%s-gateway" (tpl .Values.global.zeebe .) | quote }}
     spec:
       containers:
         - name: {{ .Chart.Name }}-gateway

--- a/zeebe-cluster/templates/gateway-deployment.yaml
+++ b/zeebe-cluster/templates/gateway-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ tpl .Values.global.zeebe . }}-gateway
+  name: {{ printf "%s-gateway" (tpl .Values.global.zeebe .) | quote }}
   labels:
     app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -27,19 +27,36 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            - containerPort: 26500
-              name: gateway
-            - containerPort: 26502
-              name: cluster
             - containerPort: 9600
-              name: monitoring
+              name: {{ .Values.service.http.name | default "http" }}
+            - containerPort: 26500
+              name: {{ .Values.service.gateway.name | default "gateway" }}
+            - containerPort: 26502
+              name: {{ .Values.service.internal.name | default "internal" }}
           env:
             - name: ZEEBE_STANDALONE_GATEWAY
               value: "true"
+            - name: ZEEBE_GATEWAY_CLUSTER_CLUSTERNAME
+              value: {{ include "zeebe-cluster.name" . }}  
             - name: ZEEBE_GATEWAY_CLUSTER_MEMBER_ID
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: ZEEBE_LOG_LEVEL
+              value: {{ .Values.gateway.logLevel | quote }}
+            - name: JAVA_TOOL_OPTIONS
+              value:
+                {{ toYaml .Values.JavaOpts | indent 14 | trim }}
+            - name: ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT
+              value: {{ printf "%s:26502" (tpl .Values.global.zeebe .) | quote }}
+            - name: ZEEBE_GATEWAY_NETWORK_HOST
+              value: 0.0.0.0
+            - name: ZEEBE_GATEWAY_CLUSTER_HOST
+              value: 0.0.0.0
+            - name: ZEEBE_GATEWAY_MONITORING_HOST
+              value: 0.0.0.0   
+          securityContext:
+            {{ toYaml .Values.podSecurityContext | indent 12 | trim }}       
           readinessProbe:
             tcpSocket:
               port: gateway

--- a/zeebe-cluster/templates/gateway-deployment.yaml
+++ b/zeebe-cluster/templates/gateway-deployment.yaml
@@ -27,11 +27,11 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            - containerPort: 9600
+            - containerPort: {{  .Values.serviceHttpPort }}
               name: {{  default "http" .Values.serviceHttpName }}
-            - containerPort: 26500
+            - containerPort: {{  .Values.serviceGatewayPort }}
               name: {{ default "gateway" .Values.serviceGatewayName  }}
-            - containerPort: 26502
+            - containerPort: {{  .Values.serviceInternalPort }}
               name: {{ default "internal" .Values.serviceInternalName  }}
           env:
             - name: ZEEBE_STANDALONE_GATEWAY

--- a/zeebe-cluster/templates/gateway-deployment.yaml
+++ b/zeebe-cluster/templates/gateway-deployment.yaml
@@ -28,11 +28,11 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: 9600
-              name: {{ .Values.service.http.name | default "http" }}
+              name: {{  default "http" .Values.serviceHttpName }}
             - containerPort: 26500
-              name: {{ .Values.service.gateway.name | default "gateway" }}
+              name: {{ default "gateway" .Values.serviceGatewayName  }}
             - containerPort: 26502
-              name: {{ .Values.service.internal.name | default "internal" }}
+              name: {{ default "internal" .Values.serviceInternalName  }}
           env:
             - name: ZEEBE_STANDALONE_GATEWAY
               value: "true"

--- a/zeebe-cluster/templates/gateway-service.yaml
+++ b/zeebe-cluster/templates/gateway-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ tpl .Values.global.zeebe . }}-gateway
+  labels:
+    app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app: {{ tpl .Values.global.zeebe . }}-gateway
+  annotations:
+{{- toYaml  .Values.annotations | nindent 4 }}   
+spec:
+  selector:
+    app: {{ tpl .Values.global.zeebe . }}-gateway 
+  ports:
+    - port: 26500
+      name: grpc
+    - port: 9600
+      name: monitoring

--- a/zeebe-cluster/templates/gateway-service.yaml
+++ b/zeebe-cluster/templates/gateway-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ tpl .Values.global.zeebe . }}-gateway
+  name: {{ printf "%s-gateway" (tpl .Values.global.zeebe .) | quote }}
   labels:
     app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -12,7 +12,9 @@ spec:
   selector:
     app: {{ tpl .Values.global.zeebe . }}-gateway 
   ports:
-    - port: 26500
-      name: grpc
-    - port: 9600
-      name: monitoring
+    - port: {{ .Values.service.http.port }}
+      protocol: TCP
+      name: {{ .Values.service.http.name | default "http" }}
+    - port: {{ .Values.service.gateway.port }}
+      protocol: TCP
+      name: {{ .Values.service.gateway.name | default "gateway" }}

--- a/zeebe-cluster/templates/gateway-service.yaml
+++ b/zeebe-cluster/templates/gateway-service.yaml
@@ -12,9 +12,9 @@ spec:
   selector:
     app: {{ tpl .Values.global.zeebe . }}-gateway 
   ports:
-    - port: {{ .Values.service.http.port }}
+    - port: {{ .Values.serviceHttpPort }}
       protocol: TCP
-      name: {{ default "http" .Values.service.http.name  }}
-    - port: {{ .Values.service.gateway.port }}
+      name: {{ default "http" .Values.serviceHttpName  }}
+    - port: {{ .Values.serviceGatewayPort }}
       protocol: TCP
-      name: {{ default "gateway" .Values.service.gateway.name }}
+      name: {{ default "gateway" .Values.serviceGatewayName }}

--- a/zeebe-cluster/templates/gateway-service.yaml
+++ b/zeebe-cluster/templates/gateway-service.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
     - port: {{ .Values.service.http.port }}
       protocol: TCP
-      name: {{ .Values.service.http.name | default "http" }}
+      name: {{ default "http" .Values.service.http.name  }}
     - port: {{ .Values.service.gateway.port }}
       protocol: TCP
-      name: {{ .Values.service.gateway.name | default "gateway" }}
+      name: {{ default "gateway" .Values.service.gateway.name }}

--- a/zeebe-cluster/templates/service.yaml
+++ b/zeebe-cluster/templates/service.yaml
@@ -12,14 +12,14 @@ metadata:
 spec:
   clusterIP: None
   publishNotReadyAddresses: true
-  type: {{ .Values.service.type }}
+  type: {{ .Values.serviceType }}
   ports:
-    - port: {{ .Values.service.http.port }}
+    - port: {{ .Values.serviceHttpPort }}
       protocol: TCP
-      name: {{ default "http" .Values.service.http.name  }}  
-    - port: {{ .Values.service.gateway.port }}
+      name: {{ default "http" .Values.serviceHttpName  }}  
+    - port: {{ .Values.serviceGatewayPort }}
       protocol: TCP
-      name: {{ default "gateway" .Values.service.gateway.name  }}
+      name: {{ default "gateway" .Values.serviceGatewayName  }}
   selector:
     app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/zeebe-cluster/templates/service.yaml
+++ b/zeebe-cluster/templates/service.yaml
@@ -16,10 +16,14 @@ spec:
   ports:
     - port: {{ .Values.service.http.port }}
       protocol: TCP
+<<<<<<< HEAD
       name: {{ .Values.service.http.name | default "http" }}  
     - port: {{ .Values.service.gateway.port }}
       protocol: TCP
       name: {{ .Values.service.gateway.name | default "gateway" }}
+=======
+      name: http  
+>>>>>>> adding standalone gateway files - not working yet
   selector:
     app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/zeebe-cluster/templates/service.yaml
+++ b/zeebe-cluster/templates/service.yaml
@@ -16,14 +16,10 @@ spec:
   ports:
     - port: {{ .Values.service.http.port }}
       protocol: TCP
-<<<<<<< HEAD
       name: {{ .Values.service.http.name | default "http" }}  
     - port: {{ .Values.service.gateway.port }}
       protocol: TCP
       name: {{ .Values.service.gateway.name | default "gateway" }}
-=======
-      name: http  
->>>>>>> adding standalone gateway files - not working yet
   selector:
     app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/zeebe-cluster/templates/service.yaml
+++ b/zeebe-cluster/templates/service.yaml
@@ -16,10 +16,10 @@ spec:
   ports:
     - port: {{ .Values.service.http.port }}
       protocol: TCP
-      name: {{ .Values.service.http.name | default "http" }}  
+      name: {{ default "http" .Values.service.http.name  }}  
     - port: {{ .Values.service.gateway.port }}
       protocol: TCP
-      name: {{ .Values.service.gateway.name | default "gateway" }}
+      name: {{ default "gateway" .Values.service.gateway.name  }}
   selector:
     app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/zeebe-cluster/templates/statefulset.yaml
+++ b/zeebe-cluster/templates/statefulset.yaml
@@ -62,13 +62,9 @@ spec:
         {{- end }}
         ports:
         - containerPort: 9600
-<<<<<<< HEAD
           name: {{ .Values.service.http.name | default "http" }}
         - containerPort: 26500
           name: {{ .Values.service.gateway.name | default "gateway" }}
-=======
-          name: http
->>>>>>> adding standalone gateway files - not working yet
         - containerPort: 26501
           name: {{ .Values.service.command.name | default "command" }}
         - containerPort: 26502

--- a/zeebe-cluster/templates/statefulset.yaml
+++ b/zeebe-cluster/templates/statefulset.yaml
@@ -62,17 +62,17 @@ spec:
         {{- end }}
         ports:
         - containerPort: 9600
-          name: {{ default "http" .Values.service.http.name  }}
+          name: {{ default "http" .Values.serviceHttpName  }}
         - containerPort: 26500
-          name: {{ default "gateway" .Values.service.gateway.name  }}
+          name: {{ default "gateway" .Values.serviceGatewayName  }}
         - containerPort: 26501
-          name: {{ default "command" .Values.service.command.name  }}
+          name: {{ default "command" .Values.servicCommandName  }}
         - containerPort: 26502
-          name: {{ default "internal" .Values.service.internal.name  }}
+          name: {{ default "internal" .Values.serviceInternalName  }}
         readinessProbe:
           httpGet:
             path: {{ .Values.probePath }}
-            port: {{ .Values.service.http.port }}
+            port: {{ .Values.serviceHttpPort }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           successThreshold: {{ .Values.readinessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/zeebe-cluster/templates/statefulset.yaml
+++ b/zeebe-cluster/templates/statefulset.yaml
@@ -62,9 +62,13 @@ spec:
         {{- end }}
         ports:
         - containerPort: 9600
+<<<<<<< HEAD
           name: {{ .Values.service.http.name | default "http" }}
         - containerPort: 26500
           name: {{ .Values.service.gateway.name | default "gateway" }}
+=======
+          name: http
+>>>>>>> adding standalone gateway files - not working yet
         - containerPort: 26501
           name: {{ .Values.service.command.name | default "command" }}
         - containerPort: 26502

--- a/zeebe-cluster/templates/statefulset.yaml
+++ b/zeebe-cluster/templates/statefulset.yaml
@@ -61,13 +61,11 @@ spec:
         {{ toYaml .Values.env | indent 8 | trim }}
         {{- end }}
         ports:
-        - containerPort: 9600
+        - containerPort: {{ .Values.serviceHttpPort  }}
           name: {{ default "http" .Values.serviceHttpName  }}
-        - containerPort: 26500
-          name: {{ default "gateway" .Values.serviceGatewayName  }}
-        - containerPort: 26501
+        - containerPort: {{ .Values.servicCommandPort  }}
           name: {{ default "command" .Values.servicCommandName  }}
-        - containerPort: 26502
+        - containerPort: {{ .Values.serviceInternalPort  }}
           name: {{ default "internal" .Values.serviceInternalName  }}
         readinessProbe:
           httpGet:

--- a/zeebe-cluster/templates/statefulset.yaml
+++ b/zeebe-cluster/templates/statefulset.yaml
@@ -62,13 +62,13 @@ spec:
         {{- end }}
         ports:
         - containerPort: 9600
-          name: {{ .Values.service.http.name | default "http" }}
+          name: {{ default "http" .Values.service.http.name  }}
         - containerPort: 26500
-          name: {{ .Values.service.gateway.name | default "gateway" }}
+          name: {{ default "gateway" .Values.service.gateway.name  }}
         - containerPort: 26501
-          name: {{ .Values.service.command.name | default "command" }}
+          name: {{ default "command" .Values.service.command.name  }}
         - containerPort: 26502
-          name: {{ .Values.service.internal.name | default "internal" }}
+          name: {{ default "internal" .Values.service.internal.name  }}
         readinessProbe:
           httpGet:
             path: {{ .Values.probePath }}

--- a/zeebe-cluster/templates/tests/test-connection.yaml
+++ b/zeebe-cluster/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args:  ['{{ .Values.global.zeebe }}:{{ .Values.service.http.port }}']
+      args:  ['{{ .Values.global.zeebe }}:{{ .Values.serviceHttpPort }}']
   restartPolicy: Never

--- a/zeebe-cluster/values.yaml
+++ b/zeebe-cluster/values.yaml
@@ -19,6 +19,7 @@ env: []
 
 gateway:
   replicas: 1
+  logLevel: warn
 
 elasticsearch:
   enabled: true
@@ -56,8 +57,6 @@ service:
   type: ClusterIP
   http:
     port: 9600
-  gateway:
-    port: 26500
   command:
     port: 26501  
   internal:

--- a/zeebe-cluster/values.yaml
+++ b/zeebe-cluster/values.yaml
@@ -53,14 +53,10 @@ image:
   pullPolicy: IfNotPresent
 labels:
   app: zeebe    
-service:
-  type: ClusterIP
-  http:
-    port: 9600
-  command:
-    port: 26501  
-  internal:
-    port: 26502
+serviceType: ClusterIP
+serviceHttpPort: 9600
+servicCommandPort: 26501     
+serviceInternalPort: 26502  
 resources: 
   requests:
     cpu: 500m

--- a/zeebe-cluster/values.yaml
+++ b/zeebe-cluster/values.yaml
@@ -55,6 +55,7 @@ labels:
   app: zeebe    
 serviceType: ClusterIP
 serviceHttpPort: 9600
+servicGatewayPort: 26500    
 servicCommandPort: 26501     
 serviceInternalPort: 26502  
 resources: 

--- a/zeebe-cluster/values.yaml
+++ b/zeebe-cluster/values.yaml
@@ -17,6 +17,9 @@ pvcSize: "10Gi"
 pvcAccessModes: [ "ReadWriteOnce" ]
 env: []
 
+gateway:
+  replicas: 1
+
 elasticsearch:
   enabled: true
   imageTag: 6.8.5


### PR DESCRIPTION
This PR introduces a Service and a Deployment for a Standalone gateway. 
It also flattens the `service.` ports and names to simplify the charts parameters as recommended in the official Helm documentation.  