### PR TITLE
fix: set securityContext under spec.containers

### DIFF
--- a/zeebe-cluster/templates/statefulset.yaml
+++ b/zeebe-cluster/templates/statefulset.yaml
@@ -80,13 +80,13 @@ spec:
           subPath: startup.sh
         - name: data
           mountPath: /usr/local/zeebe/data
+        securityContext:
+          {{ toYaml .Values.podSecurityContext | indent 12 | trim }}
       volumes:
       - name: config
         configMap:
           name: {{ tpl .Values.global.zeebe . | quote }}
           defaultMode: 0744
-      securityContext:
-{{ toYaml .Values.podSecurityContext | indent 8 }}
 {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}


### PR DESCRIPTION
**Description**

Sets `securityContext` under the containers spec.

Closes #17 