### PR TITLE
Make Service and Zeebe Container port names configurable via values.yaml

### DIFF
--- a/zeebe-cluster/templates/service.yaml
+++ b/zeebe-cluster/templates/service.yaml
@@ -16,10 +16,10 @@ spec:
   ports:
     - port: {{ .Values.service.http.port }}
       protocol: TCP
-      name: http  
+      name: {{ .Values.service.http.name | default "http" }}  
     - port: {{ .Values.service.gateway.port }}
       protocol: TCP
-      name: gateway
+      name: {{ .Values.service.gateway.name | default "gateway" }}
   selector:
     app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/zeebe-cluster/templates/statefulset.yaml
+++ b/zeebe-cluster/templates/statefulset.yaml
@@ -55,13 +55,13 @@ spec:
            {{- toYaml .Values.JavaOpts | nindent 12}}
         ports:
         - containerPort: 9600
-          name: http
+          name: {{ .Values.service.http.name | default "http" }}
         - containerPort: 26500
-          name: gateway
+          name: {{ .Values.service.gateway.name | default "gateway" }}
         - containerPort: 26501
-          name: command
+          name: {{ .Values.service.command.name | default "command" }}
         - containerPort: 26502
-          name: internal
+          name: {{ .Values.service.internal.name | default "internal" }}
         readinessProbe:
           httpGet:
             path: {{ .Values.probePath }}


### PR DESCRIPTION
This changes is to aid Istio Service Mesh port selection.

If the port names are not provided e.g.
`helm install zeebe . --debug --dry-run --set=service.http.name=http-web --set=service.gateway.name=grpc-gateway --set=service.internal.name=tcp-internal --set=service.command.name=tcp-command`

then the chart will default to the existing port names.