### PR TITLE
feat: improves startup.sh script

### DIFF
--- a/zeebe-cluster/templates/configmap.yaml
+++ b/zeebe-cluster/templates/configmap.yaml
@@ -8,21 +8,26 @@ metadata:
 apiVersion: v1
 data:
   startup.sh: |
-    #!/bin/bash -xeu
+    #!/usr/bin/env bash
+    set -eux -o pipefail
 
-    configFile=/usr/local/zeebe/conf/zeebe.cfg.toml
-    export ZEEBE_HOST=$(hostname -f)
-    export ZEEBE_NODE_ID="${HOSTNAME##*-}"
-    
-    # We need to specify all brokers as contact points for partition healing to work correctly
-    # https://github.com/zeebe-io/zeebe/issues/2684
-    ZEEBE_CONTACT_POINTS=${HOSTNAME::-1}0.$(hostname -d):26502
-    for (( i=1; i<$ZEEBE_CLUSTER_SIZE; i++ ))
-    do
-        ZEEBE_CONTACT_POINTS="${ZEEBE_CONTACT_POINTS},${HOSTNAME::-1}$i.$(hostname -d):26502"
-    done
-    export ZEEBE_CONTACT_POINTS="${ZEEBE_CONTACT_POINTS}"
-    
+    export ZEEBE_ADVERTISED_HOST=${ZEEBE_ADVERTISED_HOST:-$(hostname -f)}
+    export ZEEBE_NODE_ID=${ZEEBE_NODE_ID:-${K8S_POD_NAME##*-}}
+
+    # As the number of replicas or the DNS is not obtainable from the downward API yet,
+    # defined them here based on conventions
+    export ZEEBE_CLUSTER_SIZE=${ZEEBE_CLUSTER_SIZE:-1}
+    contactPointPrefix=${K8S_POD_NAME%-*}
+    contactPoints=${ZEEBE_CONTACT_POINTS:-""}
+    if [[ -z "${contactPoints}" ]]; then
+      for ((i=0; i<${ZEEBE_CLUSTER_SIZE}; i++))
+      do
+        contactPoints="${contactPoints},${contactPointPrefix}-$i.$(hostname -d):26502"
+      done
+
+      export ZEEBE_CONTACT_POINTS="${contactPoints}"
+    fi
+
     exec /usr/local/zeebe/bin/broker
   zeebe.cfg.toml: |
     {{ .Values.zeebeCfg }}

--- a/zeebe-cluster/templates/statefulset.yaml
+++ b/zeebe-cluster/templates/statefulset.yaml
@@ -50,6 +50,10 @@ spec:
           value: {{ .Values.clusterSize | quote }}
         - name: ZEEBE_REPLICATION_FACTOR
           value: {{ .Values.replicationFactor | quote }}
+        - name: K8S_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: JAVA_TOOL_OPTIONS
           value: 
            {{- toYaml .Values.JavaOpts | nindent 12}}


### PR DESCRIPTION
**Description**

Improves start up shell script to ensure we don't overwrite environment variables that were already set. Also exports a new environment var `K8S_POD_NAME` which passes on the pod's assigned name via the downward API, from which we extract the node ID, contact points, etc. 

Additionally we now only set the advertised host and leave the network host to the default, `0.0.0.0`, as it's not necessary to override, and doing so makes the distribution compatible with most service meshes.

Closes #42 