### PR TITLE
feat: allow setting custom environment to brokers

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,13 @@ This functionality is in beta and is subject to change. The design and code is l
 | `zeebeCfg`                 | Can be used to set several zeebe configuration options.                                                                                                                                | `null`
 | `gatewayMetrics`                 | Enables the exporting of the gateway prometheus metrics                                                                                                                                | `false`
 | `JavaOpts`                 | Set the Zeebe Cluster Broker JavaOpts. This is where you should configure the jvm heap size.                                                                                                                                | `-XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:MaxRAMPercentage=25.0 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+PrintFlagsFinal`  
-| `resources`                 | Set the Zeebe Cluster Broker Kubernetes Resource Request and Limits                                                                                                                                | `requests:`<br>  `cpu: 500m`<br>  ` memory: 1Gi`<br>`limits:`<br>  ` cpu: 1000m`<br>  ` memory: 2Gi`  
+| `resources`                 | Set the Zeebe Cluster Broker Kubernetes Resource Request and Limits                                                                                                                                | `requests:`<br>  `cpu: 500m`<br>  ` memory: 1Gi`<br>`limits:`<br>  ` cpu: 1000m`<br>  ` memory: 2Gi`
+| `env`                       |  Pass additional environment variables to the Zeebe broker pods; variables should be
+specified using standard Kubernetes raw YAML format, e.g.<br>```yaml
+env:
+  - name: ZEEBE_GATEWAY_MONITORING_ENABLED
+    value: "true"
+``` | `[]`
 | `pvcSize`                 | Set the Zeebe Cluster Persistence Volume Claim Request storage size                                                                                                                                | `10Gi`  
 | `pvcAccessModes`                 | Set the Zeebe Cluster Persistence Volume Claim Request accessModes                                                                                                                                | `[ "ReadWriteOnce" ]`  
 | `pvcStorageClassName`                 | Set the Zeebe Cluster Persistence Volume Claim Request storageClassName                                                                                                                                | ``  

--- a/zeebe-cluster/templates/statefulset.yaml
+++ b/zeebe-cluster/templates/statefulset.yaml
@@ -53,6 +53,9 @@ spec:
         - name: JAVA_TOOL_OPTIONS
           value: 
            {{- toYaml .Values.JavaOpts | nindent 12}}
+        {{- if .Values.env }}
+        {{ toYaml .Values.env | indent 8 | trim }}
+        {{- end }}
         ports:
         - containerPort: 9600
           name: {{ .Values.service.http.name | default "http" }}

--- a/zeebe-cluster/values.yaml
+++ b/zeebe-cluster/values.yaml
@@ -15,6 +15,7 @@ cpuThreadCount: "2"
 ioThreadCount: "2"
 pvcSize: "10Gi"
 pvcAccessModes: [ "ReadWriteOnce" ]
+env: []
 
 elasticsearch:
   enabled: true


### PR DESCRIPTION
**Description**

Adds value `env` which allows users to set custom environment variables on the Zeebe broker pods. The variables should be specified in the raw, standard YAML as expected by Kubernetes.

Closes #44 