### PR TITLE
feat: upgrade configuration for Zeebe 0.23.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ This functionality is in beta and is subject to change. The design and code is l
 | `nodeSelector`                 | Node selection constraint to schedule Zeebe on specific nodes                                                                                                                                | {}  
 | `tolerations`                 | Tolerations to allow Zeebe to run on dedicated nodes                                                                                                                                | []  
 | `affinity`                 | Use affinity constraints to schedule Zeebe on specific nodes                                                                                                                                | {}  
+| `elasticExporter.enabled`    | Enables the built-in Elasticsearch exporter that will export data to the configured
+Elasticsearch host | `true`
+| `extraConfig`                | You can add additional configuration path that will be loaded in addition to the
+default configuration. See the Spring Boot documentation for more. | `[]`
 
 ## Dependencies
 

--- a/zeebe-cluster/templates/configmap.yaml
+++ b/zeebe-cluster/templates/configmap.yaml
@@ -11,59 +11,42 @@ data:
     #!/usr/bin/env bash
     set -eux -o pipefail
 
-    export ZEEBE_ADVERTISED_HOST=${ZEEBE_ADVERTISED_HOST:-$(hostname -f)}
-    export ZEEBE_NODE_ID=${ZEEBE_NODE_ID:-${K8S_POD_NAME##*-}}
+    export ZEEBE_BROKER_NETWORK_ADVERTISEDHOST=${ZEEBE_BROKER_NETWORK_ADVERTISEDHOST:-$(hostname -f)}
+    export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-${K8S_POD_NAME##*-}}
 
     # As the number of replicas or the DNS is not obtainable from the downward API yet,
     # defined them here based on conventions
-    export ZEEBE_CLUSTER_SIZE=${ZEEBE_CLUSTER_SIZE:-1}
+    export ZEEBE_BROKER_CLUSTER_CLUSTERSIZE=${ZEEBE_BROKER_CLUSTER_CLUSTERSIZE:-1}
     contactPointPrefix=${K8S_POD_NAME%-*}
-    contactPoints=${ZEEBE_CONTACT_POINTS:-""}
+    contactPoints=${ZEEBE_BROKER_INITIALCONTACTPOINTS:-""}
     if [[ -z "${contactPoints}" ]]; then
-      for ((i=0; i<${ZEEBE_CLUSTER_SIZE}; i++))
+      for ((i=0; i<${ZEEBE_BROKER_CLUSTER_CLUSTERSIZE}; i++))
       do
         contactPoints="${contactPoints},${contactPointPrefix}-$i.$(hostname -d):26502"
       done
 
-      export ZEEBE_CONTACT_POINTS="${contactPoints}"
+      export ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS="${contactPoints}"
     fi
 
-    exec /usr/local/zeebe/bin/broker
-  zeebe.cfg.toml: |
-    {{ .Values.zeebeCfg }}
-    # For more information about this configuration visit: https://docs.zeebe.io/operations/the-zeebecfgtoml-file.html
-    [threads]
-    cpuThreadCount = {{ .Values.cpuThreadCount | quote }}
-    ioThreadCount = {{ .Values.ioThreadCount | quote }}
-    [gateway.monitoring]
-    enabled = {{ .Values.gatewayMetrics | default false }}
-    [[exporters]]
-    id = "elasticsearch"
-    className = "io.zeebe.exporter.ElasticsearchExporter"
-      [exporters.args]
-      url = "http://{{ .Values.global.elasticsearch.host }}:{{ .Values.global.elasticsearch.port }}"
-
-      [exporters.args.bulk]
-      delay = 5
-      size = 1_000
-
-      #[exporters.args.authentication]
-      #username = elastic
-      #password = changeme
-
-      [exporters.args.index]
-      prefix = "zeebe-record"
-      createTemplate = true
-
-      command = false
-      event = true
-      rejection = false
-
-      deployment = true
-      incident = true
-      job = true
-      message = false
-      messageSubscription = false
-      raft = false
-      workflowInstance = true
-      workflowInstanceSubscription = false
+    exec /usr/local/zeebe/bin/broker "$@"
+  broker.cfg.yml: |
+    zeebe:
+      broker:
+        threads:
+          cpuThreadCount: {{ .Values.cpuThreadCount }}
+          ioThreadCount: {{ .Values.ioThreadCount }}
+        gateway:
+          monitoring:
+            enabled: {{ .Values.gatewayMetrics | default true }}
+        {{- if .Values.elasticExporter.enabled }}
+        exporters:
+          elasticsearch:
+            className: "io.zeebe.exporter.ElasticsearchExporter"
+            args:
+              url: "http://{{ .Values.global.elasticsearch.host }}:{{ .Values.global.elasticsearch.port }}"
+              bulk:
+                delay: 5
+                size: 1000
+              index:
+                prefix: "zeebe-record"
+        {{- end }}

--- a/zeebe-cluster/templates/configmap.yaml
+++ b/zeebe-cluster/templates/configmap.yaml
@@ -8,21 +8,26 @@ metadata:
 apiVersion: v1
 data:
   startup.sh: |
-    #!/bin/bash -xeu
+    #!/usr/bin/env bash
+    set -eux -o pipefail
 
-    configFile=/usr/local/zeebe/conf/zeebe.cfg.toml
-    export ZEEBE_HOST=$(hostname -f)
-    export ZEEBE_NODE_ID="${HOSTNAME##*-}"
-    
-    # We need to specify all brokers as contact points for partition healing to work correctly
-    # https://github.com/zeebe-io/zeebe/issues/2684
-    ZEEBE_CONTACT_POINTS=${HOSTNAME::-1}0.$(hostname -d):26502
-    for (( i=1; i<$ZEEBE_CLUSTER_SIZE; i++ ))
-    do
-        ZEEBE_CONTACT_POINTS="${ZEEBE_CONTACT_POINTS},${HOSTNAME::-1}$i.$(hostname -d):26502"
-    done
-    export ZEEBE_CONTACT_POINTS="${ZEEBE_CONTACT_POINTS}"
-    
+    export ZEEBE_ADVERTISED_HOST=${ZEEBE_ADVERTISED_HOST:-$(hostname -f)}
+    export ZEEBE_NODE_ID=${ZEEBE_NODE_ID:-${K8S_POD_NAME##*-}}
+
+    # As the number of replicas or the DNS is not obtainable from the downward API yet,
+    # defined them here based on conventions
+    export ZEEBE_CLUSTER_SIZE=${ZEEBE_CLUSTER_SIZE:-1}
+    contactPointPrefix=${K8S_POD_NAME%-*}
+    contactPoints=${ZEEBE_CONTACT_POINTS:-""}
+    if [[ -z "${contactPoints}" ]]; then
+      for ((i=0; i<${ZEEBE_CLUSTER_SIZE}; i++))
+      do
+        contactPoints="${contactPoints},${contactPointPrefix}-$i.$(hostname -d):26502"
+      done
+
+      export ZEEBE_CONTACT_POINTS="${contactPoints}"
+    fi
+
     exec /usr/local/zeebe/bin/broker
   zeebe.cfg.toml: |
     {{ .Values.zeebeCfg }}

--- a/zeebe-cluster/templates/statefulset.yaml
+++ b/zeebe-cluster/templates/statefulset.yaml
@@ -50,6 +50,10 @@ spec:
           value: {{ .Values.clusterSize | quote }}
         - name: ZEEBE_REPLICATION_FACTOR
           value: {{ .Values.replicationFactor | quote }}
+        - name: K8S_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: JAVA_TOOL_OPTIONS
           value: 
            {{- toYaml .Values.JavaOpts | nindent 12}}

--- a/zeebe-cluster/templates/statefulset.yaml
+++ b/zeebe-cluster/templates/statefulset.yaml
@@ -41,14 +41,20 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+          - "--spring.profiles.active=default"
+          - "--spring.config.location=file:./config/zeebe.cfg.yaml"
+          {{- if .Values.extraConfig }}
+          - {{ printf "--spring.config.additional-location=%s" (join "," .Values.extraConfig) | quote }}
+          {{- end }}
         env:
         - name: ZEEBE_LOG_LEVEL
           value: debug
-        - name: ZEEBE_PARTITIONS_COUNT
+        - name: ZEEBE_BROKER_CLUSTER_PARTITIONSCOUNT
           value: {{ .Values.partitionCount | quote }}
-        - name: ZEEBE_CLUSTER_SIZE
+        - name: ZEEBE_BROKER_CLUSTER_CLUSTERSIZE
           value: {{ .Values.clusterSize | quote }}
-        - name: ZEEBE_REPLICATION_FACTOR
+        - name: ZEEBE_BROKER_CLUSTER_REPLICATIONFACTOR
           value: {{ .Values.replicationFactor | quote }}
         - name: K8S_POD_NAME
           valueFrom:
@@ -77,8 +83,8 @@ spec:
           {{- toYaml .Values.resources | nindent 12 }}
         volumeMounts:
         - name: config
-          mountPath: /usr/local/zeebe/conf/zeebe.cfg.toml
-          subPath: zeebe.cfg.toml
+          mountPath: /usr/local/zeebe/config/zeebe.cfg.yaml
+          subPath: broker.cfg.yml
         - name: config
           mountPath: /usr/local/bin/startup.sh
           subPath: startup.sh

--- a/zeebe-cluster/values.yaml
+++ b/zeebe-cluster/values.yaml
@@ -15,6 +15,10 @@ cpuThreadCount: "2"
 ioThreadCount: "2"
 pvcSize: "10Gi"
 pvcAccessModes: [ "ReadWriteOnce" ]
+extraConfigPaths: []
+
+elasticExporter:
+  enabled: true
 
 elasticsearch:
   enabled: true
@@ -44,7 +48,7 @@ JavaOpts: |
   -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log
 image:
   repository: camunda/zeebe
-  tag: 0.22.1
+  tag: 0.23.0-alpha2
   pullPolicy: IfNotPresent
 labels:
   app: zeebe    


### PR DESCRIPTION
**Description**

Upgrades configuration to be 0.23.x compatible - note that this is not backwards compatible with any image pre 0.23.x. Adds an extra value, `extraConfig`, which allows users to add additional Spring Boot configuration paths as described by the Spring Boot documentation.

As a bonus, allows enabling/disabling the Elasticsearch exporter via the value `elasticExporter.enabled`. When enabled, the proper configuration will be added to the `zeebe.cfg.yaml`.

Tested against `0.23.0-alpha2` - the tag is also fixed to this now, but should be updated to the correct stable release when available.

Closes #46