### PR TITLE
Change gateway-deployment readiness port to use .Values.serviceGatewayName

### DIFF
--- a/zeebe-cluster/templates/gateway-deployment.yaml
+++ b/zeebe-cluster/templates/gateway-deployment.yaml
@@ -59,6 +59,6 @@ spec:
             {{ toYaml .Values.podSecurityContext | indent 12 | trim }}       
           readinessProbe:
             tcpSocket:
-              port: gateway
+              port: {{ default "gateway" .Values.serviceGatewayName  }}
             initialDelaySeconds: 20
             periodSeconds: 5


### PR DESCRIPTION
Change gateway-deployment readiness port to use .Values.serviceGatewayName if specified in the values.yaml, otherwise default to "gateway".