### PR TITLE
feat: upgrade Zeebe to 0.23.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CHARTMUSEUM_CREDS_PSW := $(shell cat /builder/home/basic-auth-pass.json)
 init:
 	helm init --client-only
 
-setup: init
+setup: 
 	helm repo add jenkins-x http://chartmuseum.jenkins-x.io
 	helm repo add elastic http://helm.elastic.co
 	helm repo add releases ${CHART_REPO}

--- a/README.md
+++ b/README.md
@@ -72,6 +72,92 @@ env:
     value: "true"
 ```
 
+
+## Adding dynamic exporters to Zeebe Brokers
+
+This chart supports the addition of Zeebe Exporters by using initContainer as shown in the following example:
+
+```
+extraInitContainers: |
+  - name: init-exporters-hazelcast
+    image: busybox:1.28
+    command: ['/bin/sh', '-c']
+    args: ['wget --no-check-certificate https://repo1.maven.org/maven2/io/zeebe/hazelcast/zeebe-hazelcast-exporter/0.8.0-alpha1/zeebe-hazelcast-exporter-0.8.0-alpha1-jar-with-dependencies.jar -O /exporters/zeebe-hazelcast-exporter.jar; ls -al']
+    volumeMounts:
+    - name: exporters
+      mountPath: /exporters/
+  - name: init-exporters-kafka
+    image: busybox:1.28
+    command: ['/bin/sh', '-c']
+    args: ['wget --no-check-certificate https://github.com/zeebe-io/zeebe-kafka-exporter/releases/download/1.1.0/zeebe-kafka-exporter-1.1.0-uber.jar -O /exporters/zeebe-kafka-exporter.jar; ls -al']
+    volumeMounts:
+    - name: exporters
+      mountPath: /exporters/    
+zeebeCfg: |- 
+  [[exporters]]
+  id = "elasticsearch"
+  className = "io.zeebe.exporter.ElasticsearchExporter"
+    [exporters.args]
+    url = "http://elasticsearch-master:9200"
+    [exporters.args.bulk]
+    delay = 5
+    size = 1_000
+    #[exporters.args.authentication]
+    #username = elastic
+    #password = changeme
+    [exporters.args.index]
+    prefix = "zeebe-record"
+    createTemplate = true
+    command = false
+    event = true
+    rejection = false
+    deployment = true
+    incident = true
+    job = true
+    message = false
+    messageSubscription = false
+    raft = false
+    workflowInstance = true
+    workflowInstanceSubscription = false
+  
+  [[exporters]]
+  id = "hazelcast"
+  className = "io.zeebe.hazelcast.exporter.HazelcastExporter"
+    [exporters.args]
+    enabledValueTypes = "JOB,WORKFLOW_INSTANCE,DEPLOYMENT,INCIDENT,TIMER,VARIABLE,MESSAGE,MESSAGE_SUBSCRIPTION,MESSAGE_START_EVENT_SUBSCRIPTION"
+    updatePosition = false
+  
+  [[exporters]]
+  id = "kafka"
+  className = "io.zeebe.exporters.kafka.KafkaExporter"
+    [exporters.args]
+    maxInFlightRecords = 1000
+    inFlightRecordCheckIntervalMs = 1000
+    
+    [exporters.args.producer]
+    servers = [ "my-kafka:9092" ]
+    requestTimeoutMs = 5000
+    closeTimeoutMs = 5000
+    clientId = "zeebe"    
+    maxConcurrentRequests = 3
+    [exporters.args.producer.config]
+    [exporters.args.records]
+    defaults = { type = [ "event" ], topic = "zeebe" }
+    deployment = { topic = "zeebe-deployment" }
+    incident = { topic = "zeebe-incident" }
+    jobBatch = { topic = "zeebe-job-batch" }
+    job = { topic = "zeebe-job" }
+    message = { topic = "zeebe-message" }
+    messageSubscription = { topic = "zeebe-message-subscription" }
+    messageStartEventSubscription = { topic = "zeebe-message-subscription-start-event" }
+    raft = { topic = "zeebe-raft" }
+    timer = { topic = "zeebe-timer" }
+    variable = { topic = "zeebe-variable" }
+    workflowInstance = { topic = "zeebe-workflow" }
+    workflowInstanceSubscription = { topic = "zeebe-workflow-subscription" }   
+```
+This example is downloading the exporters Jar from an URL and adding the Jars to the `exporters` directory that will be scanned for jars and added to the zeebe broker classpath. 
+
 ## Dependencies
 
 This chart currently depends on the following charts:

--- a/zeebe-cluster/templates/configmap.yaml
+++ b/zeebe-cluster/templates/configmap.yaml
@@ -22,7 +22,7 @@ data:
     if [[ -z "${contactPoints}" ]]; then
       for ((i=0; i<${ZEEBE_BROKER_CLUSTER_CLUSTERSIZE}; i++))
       do
-        contactPoints="${contactPoints},${contactPointPrefix}-$i.$(hostname -d):26502"
+        contactPoints="${contactPoints},${contactPointPrefix}-$i.$(hostname -d):{{ .Values.serviceInternalPort }}"
       done
 
       export ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS="${contactPoints}"

--- a/zeebe-cluster/templates/configmap.yaml
+++ b/zeebe-cluster/templates/configmap.yaml
@@ -11,23 +11,22 @@ data:
     #!/usr/bin/env bash
     set -eux -o pipefail
 
-    export ZEEBE_ADVERTISED_HOST=${ZEEBE_ADVERTISED_HOST:-$(hostname -f)}
-    export ZEEBE_NODE_ID=${ZEEBE_NODE_ID:-${K8S_POD_NAME##*-}}
+    export ZEEBE_BROKER_NETWORK_ADVERTISEDHOST=${ZEEBE_BROKER_NETWORK_ADVERTISEDHOST:-$(hostname -f)}
+    export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-${K8S_POD_NAME##*-}}
 
     # As the number of replicas or the DNS is not obtainable from the downward API yet,
     # defined them here based on conventions
-    export ZEEBE_CLUSTER_SIZE=${ZEEBE_CLUSTER_SIZE:-1}
+    export ZEEBE_BROKER_CLUSTER_CLUSTERSIZE=${ZEEBE_BROKER_CLUSTER_CLUSTERSIZE:-1}
     contactPointPrefix=${K8S_POD_NAME%-*}
-    contactPoints=${ZEEBE_CONTACT_POINTS:-""}
+    contactPoints=${ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS:-""}
     if [[ -z "${contactPoints}" ]]; then
-      for ((i=0; i<${ZEEBE_CLUSTER_SIZE}; i++))
+      for ((i=0; i<${ZEEBE_BROKER_CLUSTER_CLUSTERSIZE}; i++))
       do
         contactPoints="${contactPoints},${contactPointPrefix}-$i.$(hostname -d):26502"
       done
 
-      export ZEEBE_CONTACT_POINTS="${contactPoints}"
+      export ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS="${contactPoints}"
     fi
-
     
     if [ "$(ls -A /exporters/)" ]; then
       mkdir /usr/local/zeebe/exporters/
@@ -37,43 +36,5 @@ data:
     fi
 
     exec /usr/local/zeebe/bin/broker
-  zeebe.cfg.toml: |
-    {{ .Values.zeebeCfg }}
-    # For more information about this configuration visit: https://docs.zeebe.io/operations/the-zeebecfgtoml-file.html
-    [threads]
-    cpuThreadCount = {{ .Values.cpuThreadCount | quote }}
-    ioThreadCount = {{ .Values.ioThreadCount | quote }}
-    [gateway]
-    enable = false
-    [gateway.monitoring]
-    enabled = {{ .Values.gatewayMetrics | default false }}
-    [[exporters]]
-    id = "elasticsearch"
-    className = "io.zeebe.exporter.ElasticsearchExporter"
-      [exporters.args]
-      url = "http://{{ .Values.global.elasticsearch.host }}:{{ .Values.global.elasticsearch.port }}"
-
-      [exporters.args.bulk]
-      delay = 5
-      size = 1_000
-
-      #[exporters.args.authentication]
-      #username = elastic
-      #password = changeme
-
-      [exporters.args.index]
-      prefix = "zeebe-record"
-      createTemplate = true
-
-      command = false
-      event = true
-      rejection = false
-
-      deployment = true
-      incident = true
-      job = true
-      message = false
-      messageSubscription = false
-      raft = false
-      workflowInstance = true
-      workflowInstanceSubscription = false
+  application.yaml: |
+    {{ toYaml .Values.zeebeCfg }}

--- a/zeebe-cluster/templates/gateway-deployment.yaml
+++ b/zeebe-cluster/templates/gateway-deployment.yaml
@@ -38,7 +38,7 @@ spec:
               value: "true"
             - name: ZEEBE_GATEWAY_CLUSTER_CLUSTERNAME
               value: {{ include "zeebe-cluster.name" . }}  
-            - name: ZEEBE_GATEWAY_CLUSTER_MEMBER_ID
+            - name: ZEEBE_GATEWAY_CLUSTER_MEMBERID
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
@@ -47,14 +47,20 @@ spec:
             - name: JAVA_TOOL_OPTIONS
               value:
                 {{ toYaml .Values.JavaOpts | indent 14 | trim }}
-            - name: ZEEBE_GATEWAY_CONTACT_POINT
-              value: {{ printf "%s:26502" (tpl .Values.global.zeebe .) | quote }}
+            - name: ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT
+              value: {{ printf "%s:%d" (tpl .Values.global.zeebe .) .Values.serviceInternalPort | quote }}
             - name: ZEEBE_GATEWAY_NETWORK_HOST
               value: 0.0.0.0
+            - name: ZEEBE_GATEWAY_NETWORK_PORT
+              value: {{  .Values.serviceGatewayPort }}
             - name: ZEEBE_GATEWAY_CLUSTER_HOST
               value: 0.0.0.0
+            - name: ZEEBE_GATEWAY_CLUSTER_PORT
+              value: {{  .Values.serviceInternalPort }}
             - name: ZEEBE_GATEWAY_MONITORING_HOST
               value: 0.0.0.0   
+            - name: ZEEBE_GATEWAY_MONITORING_PORT
+              value: {{  .Values.serviceHttpPort }}              
           securityContext:
             {{ toYaml .Values.podSecurityContext | indent 12 | trim }}       
           readinessProbe:

--- a/zeebe-cluster/templates/gateway-deployment.yaml
+++ b/zeebe-cluster/templates/gateway-deployment.yaml
@@ -45,8 +45,7 @@ spec:
             - name: ZEEBE_LOG_LEVEL
               value: {{ .Values.gateway.logLevel | quote }}
             - name: JAVA_TOOL_OPTIONS
-              value:
-                {{ toYaml .Values.JavaOpts | indent 14 | trim }}
+              value: {{ .Values.JavaOpts | quote }}
             - name: ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT
               value: {{ printf "%s:%d" (tpl .Values.global.zeebe .) .Values.serviceInternalPort | quote }}
             - name: ZEEBE_GATEWAY_NETWORK_HOST

--- a/zeebe-cluster/templates/gateway-deployment.yaml
+++ b/zeebe-cluster/templates/gateway-deployment.yaml
@@ -47,7 +47,7 @@ spec:
             - name: JAVA_TOOL_OPTIONS
               value: {{ .Values.JavaOpts | quote }}
             - name: ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT
-              value: {{ printf "%s:%d" (tpl .Values.global.zeebe .) .Values.serviceInternalPort | quote }}
+              value: {{ tpl .Values.global.zeebe . }}:{{ .Values.serviceInternalPort }}
             - name: ZEEBE_GATEWAY_NETWORK_HOST
               value: 0.0.0.0
             - name: ZEEBE_GATEWAY_NETWORK_PORT

--- a/zeebe-cluster/templates/gateway-deployment.yaml
+++ b/zeebe-cluster/templates/gateway-deployment.yaml
@@ -51,15 +51,15 @@ spec:
             - name: ZEEBE_GATEWAY_NETWORK_HOST
               value: 0.0.0.0
             - name: ZEEBE_GATEWAY_NETWORK_PORT
-              value: {{  .Values.serviceGatewayPort }}
+              value: {{  .Values.serviceGatewayPort | quote }}
             - name: ZEEBE_GATEWAY_CLUSTER_HOST
               value: 0.0.0.0
             - name: ZEEBE_GATEWAY_CLUSTER_PORT
-              value: {{  .Values.serviceInternalPort }}
+              value: {{  .Values.serviceInternalPort | quote }}
             - name: ZEEBE_GATEWAY_MONITORING_HOST
               value: 0.0.0.0   
             - name: ZEEBE_GATEWAY_MONITORING_PORT
-              value: {{  .Values.serviceHttpPort }}              
+              value: {{  .Values.serviceHttpPort | quote }}              
           securityContext:
             {{ toYaml .Values.podSecurityContext | indent 12 | trim }}       
           readinessProbe:

--- a/zeebe-cluster/templates/statefulset.yaml
+++ b/zeebe-cluster/templates/statefulset.yaml
@@ -66,14 +66,12 @@ spec:
           value: {{  .Values.serviceInternalPort }}
         - name: ZEEBE_BROKER_NETWORK_MONITORINGAPI_PORT
           value: {{  .Values.serviceHttpPort }}         
-        
         - name: K8S_POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name              
         - name: JAVA_TOOL_OPTIONS
-          value: 
-           {{- toYaml .Values.JavaOpts | nindent 12}}
+          value: {{ .Values.JavaOpts | quote }}
         {{- if .Values.env }}
         {{ toYaml .Values.env | indent 8 | trim }}
         {{- end }}

--- a/zeebe-cluster/templates/statefulset.yaml
+++ b/zeebe-cluster/templates/statefulset.yaml
@@ -45,27 +45,27 @@ spec:
         - name: ZEEBE_LOG_LEVEL
           value: debug
         - name: ZEEBE_BROKER_CLUSTER_PARTITIONSCOUNT
-          value: {{ .Values.partitionCount }}
+          value: {{ .Values.partitionCount | quote }}
         - name: ZEEBE_BROKER_CLUSTER_CLUSTERSIZE
-          value: {{ .Values.clusterSize }}
+          value: {{ .Values.clusterSize | quote }}
         - name: ZEEBE_BROKER_CLUSTER_REPLICATIONFACTOR
-          value: {{ .Values.replicationFactor }}
+          value: {{ .Values.replicationFactor | quote }}
         - name: ZEEBE_BROKER_THREADS_CPUTHREADCOUNT
-          value: {{ .Values.cpuThreadCount }}
+          value: {{ .Values.cpuThreadCount  | quote }}
         - name: ZEEBE_BROKER_THREADS_IOTHREADCOUNT
-          value: {{ .Values.ioThreadCount }}
+          value: {{ .Values.ioThreadCount  | quote }}
         - name: ZEEBE_BROKER_GATEWAY_ENABLE
-          value: false
+          value: "false"
         - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME
           value: "io.zeebe.exporter.ElasticsearchExporter"
         - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL
           value: "http://{{ .Values.global.elasticsearch.host }}:{{ .Values.global.elasticsearch.port }}"
         - name: ZEEBE_BROKER_NETWORK_COMMANDAPI_PORT
-          value: {{ .Values.serviceCommandPort  }}
+          value: {{ .Values.serviceCommandPort  | quote }}
         - name: ZEEBE_BROKER_NETWORK_INTERNALAPI_PORT
-          value: {{  .Values.serviceInternalPort }}
+          value: {{  .Values.serviceInternalPort | quote }}
         - name: ZEEBE_BROKER_NETWORK_MONITORINGAPI_PORT
-          value: {{  .Values.serviceHttpPort }}         
+          value: {{  .Values.serviceHttpPort | quote }}         
         - name: K8S_POD_NAME
           valueFrom:
             fieldRef:

--- a/zeebe-cluster/templates/statefulset.yaml
+++ b/zeebe-cluster/templates/statefulset.yaml
@@ -44,16 +44,33 @@ spec:
         env:
         - name: ZEEBE_LOG_LEVEL
           value: debug
-        - name: ZEEBE_PARTITIONS_COUNT
-          value: {{ .Values.partitionCount | quote }}
-        - name: ZEEBE_CLUSTER_SIZE
-          value: {{ .Values.clusterSize | quote }}
-        - name: ZEEBE_REPLICATION_FACTOR
-          value: {{ .Values.replicationFactor | quote }}
+        - name: ZEEBE_BROKER_CLUSTER_PARTITIONSCOUNT
+          value: {{ .Values.partitionCount }}
+        - name: ZEEBE_BROKER_CLUSTER_CLUSTERSIZE
+          value: {{ .Values.clusterSize }}
+        - name: ZEEBE_BROKER_CLUSTER_REPLICATIONFACTOR
+          value: {{ .Values.replicationFactor }}
+        - name: ZEEBE_BROKER_THREADS_CPUTHREADCOUNT
+          value: {{ .Values.cpuThreadCount }}
+        - name: ZEEBE_BROKER_THREADS_IOTHREADCOUNT
+          value: {{ .Values.ioThreadCount }}
+        - name: ZEEBE_BROKER_GATEWAY_ENABLE
+          value: false
+        - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME
+          value: "io.zeebe.exporter.ElasticsearchExporter"
+        - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL
+          value: "http://{{ .Values.global.elasticsearch.host }}:{{ .Values.global.elasticsearch.port }}"
+        - name: ZEEBE_BROKER_NETWORK_COMMANDAPI_PORT
+          value: {{ .Values.serviceCommandPort  }}
+        - name: ZEEBE_BROKER_NETWORK_INTERNALAPI_PORT
+          value: {{  .Values.serviceInternalPort }}
+        - name: ZEEBE_BROKER_NETWORK_MONITORINGAPI_PORT
+          value: {{  .Values.serviceHttpPort }}         
+        
         - name: K8S_POD_NAME
           valueFrom:
             fieldRef:
-              fieldPath: metadata.name
+              fieldPath: metadata.name              
         - name: JAVA_TOOL_OPTIONS
           value: 
            {{- toYaml .Values.JavaOpts | nindent 12}}
@@ -78,8 +95,8 @@ spec:
           {{- toYaml .Values.resources | nindent 12 }}
         volumeMounts:
         - name: config
-          mountPath: /usr/local/zeebe/conf/zeebe.cfg.toml
-          subPath: zeebe.cfg.toml
+          mountPath: /usr/local/zeebe/config/application.yaml
+          subPath: application.yaml
         - name: config
           mountPath: /usr/local/bin/startup.sh
           subPath: startup.sh

--- a/zeebe-cluster/values.yaml
+++ b/zeebe-cluster/values.yaml
@@ -10,7 +10,7 @@ global:
 
 image:
   repository: camunda/zeebe
-  tag: 0.23.0
+  tag: 0.23.1
   pullPolicy: IfNotPresent
 
 clusterSize: "3"

--- a/zeebe-cluster/values.yaml
+++ b/zeebe-cluster/values.yaml
@@ -8,6 +8,11 @@ global:
     port: 9200 
   zeebe: "{{ .Release.Name }}-zeebe"
 
+image:
+  repository: camunda/zeebe
+  tag: 0.23.0
+  pullPolicy: IfNotPresent
+
 clusterSize: "3"
 partitionCount: "3"
 replicationFactor: "3"
@@ -38,7 +43,7 @@ JavaOpts: |
   -XX:+UseParallelGC 
   -XX:MinHeapFreeRatio=5
   -XX:MaxHeapFreeRatio=10
-  -XX:MaxRAMPercentage=25.0 
+  -XX:MaxRAMPercentage=25.0
   -XX:GCTimeRatio=4 
   -XX:AdaptiveSizePolicyWeight=90
   -XX:+PrintFlagsFinal
@@ -47,10 +52,7 @@ JavaOpts: |
   -XX:+HeapDumpOnOutOfMemoryError
   -XX:HeapDumpPath=/usr/local/zeebe/data
   -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log
-image:
-  repository: camunda/zeebe
-  tag: 0.22.1
-  pullPolicy: IfNotPresent
+
 labels:
   app: zeebe    
 serviceType: ClusterIP

--- a/zeebe-cluster/values.yaml
+++ b/zeebe-cluster/values.yaml
@@ -39,12 +39,12 @@ prometheus:
   servicemonitor:
     enabled: false
 
-JavaOpts: |
-  -XX:+UseParallelGC 
+JavaOpts: >-
+  -XX:+UseParallelGC
   -XX:MinHeapFreeRatio=5
   -XX:MaxHeapFreeRatio=10
   -XX:MaxRAMPercentage=25.0
-  -XX:GCTimeRatio=4 
+  -XX:GCTimeRatio=4
   -XX:AdaptiveSizePolicyWeight=90
   -XX:+PrintFlagsFinal
   -Xmx4g


### PR DESCRIPTION
**Description**

This PR updates the chart to use Zeebe 0.23.0 by default, and updates how we configure Zeebe. This means:

- Default image tag is updated to 0.23.0
- Environment variables in both the broker StatefulSet and the gateway Deployment were updated to the new Spring Boot convention
- `zeebeCfg` value was kept, and is now meant to be arbitrary YAML that can be added as a configuration file. The rest of the configuration file was dropped in favour of environment variables
- Port overrides were corrected for both broker and gateway (previously they were not being set in the config, only on the service)
- `JAVA_TOOL_OPTIONS` was fixed to use folded YAML (see https://helm.sh/docs/chart_template_guide/yaml_techniques/#folded-multi-line-strings)

**TODO**

As this is a draft PR, there's still a few things to do:

1. Add example of new YAML `zeebeCfg` (which can be mounted to both gateway and broker)
1. Test the changes against real infrastructure