### PR TITLE
chore: add command API port in broker service

### DIFF
--- a/zeebe-cluster/templates/service.yaml
+++ b/zeebe-cluster/templates/service.yaml
@@ -20,6 +20,9 @@ spec:
     - port: {{ .Values.serviceInternalPort }}
       protocol: TCP
       name: {{ default "internal" .Values.serviceInternalName  }}
+    - port: {{ .Values.serviceCommandPort }}
+      protocol: TCP
+      name: {{ default "command" .Values.serviceCommandName }}
   selector:
     app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
Adds the command API port in the broker service; currently we only expose the monitoring and internal ports.

Closes #57 