### PR TITLE
Fix Test Connection pod template

### DIFF
--- a/zeebe-cluster/templates/tests/test-connection.yaml
+++ b/zeebe-cluster/templates/tests/test-connection.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ .Values.global.zeebe }}-test-connection"
+  name: "{{ tpl .Values.global.zeebe . }}-test-connection"
   labels:
 {{ include "zeebe-cluster.labels" . | indent 4 }}
   annotations:
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args:  ['{{ .Values.global.zeebe }}:{{ .Values.serviceHttpPort }}']
+      args:  ['{{ tpl .Values.global.zeebe . }}:{{ .Values.serviceHttpPort }}']
   restartPolicy: Never


### PR DESCRIPTION
Since we embed templating in values.yaml in `global.zeebe`, we have to tell Helm to explicitly re-template any file we reference it in. This is already done in all other files in this chart, this one file is the only exception.


Fixes https://github.com/zeebe-io/zeebe-cluster-helm/issues/59.