### PR TITLE
Add PodDisruptionBudgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ This functionality is in beta and is subject to change. The design and code is l
 | `JavaOpts`                 | Set the Zeebe Cluster Broker JavaOpts. This is where you should configure the jvm heap size.                                                                                                                                | `-XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:MaxRAMPercentage=25.0 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+PrintFlagsFinal`  
 | `resources`                 | Set the Zeebe Cluster Broker Kubernetes Resource Request and Limits                                                                                                                                | `requests:`<br>  `cpu: 500m`<br>  ` memory: 1Gi`<br>`limits:`<br>  ` cpu: 1000m`<br>  ` memory: 2Gi`
 | `env`                       |  Pass additional environment variables to the Zeebe broker pods; <br> variables should be specified using standard Kubernetes raw YAML format. See below for an example.| `[]`
+| `podDisruptionBudget.enabled`         | Create a podDisruptionBudget for the broker pods | `false`
+| `podDisruptionBudget.minAvailable`         | Minimum number of available broker pods for PodDisruptionBudget |
+| `podDisruptionBudget.maxUnavailable`       | Maximum number of unavailable broker pods for PodDisruptionBudget | `1`
 | `pvcSize`                 | Set the Zeebe Cluster Persistence Volume Claim Request storage size                                                                                                                                | `10Gi`  
 | `pvcAccessModes`                 | Set the Zeebe Cluster Persistence Volume Claim Request accessModes                                                                                                                                | `[ "ReadWriteOnce" ]`  
 | `pvcStorageClassName`                 | Set the Zeebe Cluster Persistence Volume Claim Request storageClassName                                                                                                                                | ``  
@@ -56,6 +59,9 @@ This functionality is in beta and is subject to change. The design and code is l
 | `gateway.logLevel`         | The log level of the gateway, one of: ERROR, WARN, INFO, DEBUG, TRACE | `warn`
 | `gateway.env`         |  Pass additional environment variables to the Zeebe broker pods; <br> variables should be specified using standard Kubernetes raw YAML format. See below for an example.| `[]`
 | `gateway.podAnnotations`         | Annotations to be applied to the gateway Deployment pod template | ``
+| `gateway.podDisruptionBudget.enabled`         | Create a PodDisruptionBudget for the gateway pods | `false`
+| `gateway.podDisruptionBudget.minAvailable`         | minimum number of available gateway pods for PodDisruptionBudget | `1`
+| `gateway.podDisruptionBudget.maxUnavailable`       | maximum number of unavailable gateway pods for PodDisruptionBudget |
 | `serviceHttpPort`         | The http port used by the brokers and the gateway| `9600`
 | `serviceGatewayPort`         | The gateway port used by the gateway | `26500`
 | `serviceInternalPort`         | The internal port used by the brokers and the gateway | `26502`

--- a/zeebe-cluster/templates/gateway-poddisruptionbudget.yaml
+++ b/zeebe-cluster/templates/gateway-poddisruptionbudget.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.gateway.podDisruptionBudget.enabled  -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ printf "%s-gateway" (tpl .Values.global.zeebe .) | quote }}
+  labels:
+    app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app: {{ printf "%s-gateway" (tpl .Values.global.zeebe .) | quote }}
+spec:
+  minAvailable: {{ .Values.gateway.podDisruptionBudget.minAvailable }}
+  maxUnavailable: {{ .Values.gateway.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      app: {{ printf "%s-gateway" (tpl .Values.global.zeebe .) | quote }}
+{{- end }}

--- a/zeebe-cluster/templates/poddisruptionbudget.yaml
+++ b/zeebe-cluster/templates/poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ tpl .Values.global.zeebe . | quote }}
+  labels:
+    app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app: {{ tpl .Values.global.zeebe . | quote }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app: {{ tpl .Values.global.zeebe . | quote }}
+{{- end }}

--- a/zeebe-cluster/values.yaml
+++ b/zeebe-cluster/values.yaml
@@ -26,7 +26,10 @@ gateway:
   replicas: 1
   logLevel: warn
   env: []
-
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    maxUnavailable:
 
 elasticsearch:
   enabled: true
@@ -75,6 +78,10 @@ readinessProbe:
   periodSeconds: 10
   successThreshold: 1
   timeoutSeconds: 1
+podDisruptionBudget:
+  enabled: false
+  minAvailable:
+  maxUnavailable: 1
 
 nodeSelector: {}
 


### PR DESCRIPTION
Create PodDisruptionBudgets for the gateway deployment and broker statefulset.

By default, PDBs are not created.

https://kubernetes.io/docs/tasks/run-application/configure-pdb/
https://kubernetes.io/docs/concepts/workloads/pods/disruptions/

Fixes #60 
