### PR TITLE
feat(gateway): support arbitary env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This functionality is in beta and is subject to change. The design and code is l
 | `affinity`                 | Use affinity constraints to schedule Zeebe on specific nodes                                                                                                                                | {}  
 | `gateway.replicas`         | The number of standalone gateways that should be deployed | `1`
 | `gateway.logLevel`         | The log level of the gateway, one of: ERROR, WARN, INFO, DEBUG, TRACE | `warn`
+| `gateway.env`         |  Pass additional environment variables to the Zeebe broker pods; <br> variables should be specified using standard Kubernetes raw YAML format. See below for an example.| `[]`
 | `serviceHttpPort`         | The http port used by the brokers and the gateway| `9600`
 | `serviceGatewayPort`         | The gateway port used by the gateway | `26500`
 | `serviceInternalPort`         | The internal port used by the brokers and the gateway | `26502`

--- a/zeebe-cluster/templates/gateway-deployment.yaml
+++ b/zeebe-cluster/templates/gateway-deployment.yaml
@@ -59,9 +59,12 @@ spec:
             - name: ZEEBE_GATEWAY_MONITORING_HOST
               value: 0.0.0.0   
             - name: ZEEBE_GATEWAY_MONITORING_PORT
-              value: {{  .Values.serviceHttpPort | quote }}              
+              value: {{  .Values.serviceHttpPort | quote }}
+            {{- if .Values.gateway.env }}
+            {{ toYaml .Values.gateway.env | indent 12 | trim }}
+            {{- end }}
           securityContext:
-            {{ toYaml .Values.podSecurityContext | indent 12 | trim }}       
+            {{ toYaml .Values.podSecurityContext | indent 12 | trim }}
           readinessProbe:
             tcpSocket:
               port: {{ default "gateway" .Values.serviceGatewayName  }}

--- a/zeebe-cluster/values.yaml
+++ b/zeebe-cluster/values.yaml
@@ -25,6 +25,8 @@ env: []
 gateway:
   replicas: 1
   logLevel: warn
+  env: []
+
 
 elasticsearch:
   enabled: true


### PR DESCRIPTION
Adds support for env variables on the gateway.

Configuration looks like this:

```yaml
 gateway:
   replicas: 1
   logLevel: warn
   env: 
    - name: ZEEBE_LOG_APPENDER
      value: Stackdriver
```

Tested via `helm template zeebe-cluster`, result for the gateway:

```yaml
---
# Source: zeebe-cluster/templates/gateway-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: "RELEASE-NAME-zeebe-gateway"
  labels:
    app.kubernetes.io/name: zeebe-cluster
    app.kubernetes.io/instance: RELEASE-NAME
    app: "RELEASE-NAME-zeebe-gateway"
  annotations:   
spec:
  replicas: 1
  selector:
    matchLabels:
      app: "RELEASE-NAME-zeebe-gateway"
  template:
    metadata:  
      labels:
        app.kubernetes.io/name: zeebe-cluster
        app.kubernetes.io/instance: RELEASE-NAME
        app: "RELEASE-NAME-zeebe-gateway"
    spec:
      containers:
        - name: zeebe-cluster-gateway
          image: "camunda/zeebe:0.23.1"
          imagePullPolicy: IfNotPresent
          ports:
            - containerPort: 9600
              name: http
            - containerPort: 26500
              name: gateway
            - containerPort: 26502
              name: internal
          env:
            - name: ZEEBE_STANDALONE_GATEWAY
              value: "true"
            - name: ZEEBE_GATEWAY_CLUSTER_CLUSTERNAME
              value: RELEASE-NAME-zeebe  
            - name: ZEEBE_GATEWAY_CLUSTER_MEMBERID
              valueFrom:
                fieldRef:
                  fieldPath: metadata.name
            - name: ZEEBE_LOG_LEVEL
              value: "warn"
            - name: JAVA_TOOL_OPTIONS
              value: "-XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:MaxRAMPercentage=25.0 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+PrintFlagsFinal -Xmx4g -Xms4g -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/zeebe/data -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log"
            - name: ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT
              value: RELEASE-NAME-zeebe:26502
            - name: ZEEBE_GATEWAY_NETWORK_HOST
              value: 0.0.0.0
            - name: ZEEBE_GATEWAY_NETWORK_PORT
              value: "26500"
            - name: ZEEBE_GATEWAY_CLUSTER_HOST
              value: 0.0.0.0
            - name: ZEEBE_GATEWAY_CLUSTER_PORT
              value: "26502"
            - name: ZEEBE_GATEWAY_MONITORING_HOST
              value: 0.0.0.0   
            - name: ZEEBE_GATEWAY_MONITORING_PORT
              value: "9600"
            - name: ZEEBE_LOG_APPENDER
              value: Stackdriver           
          securityContext:
            null       
          readinessProbe:
            tcpSocket:
              port: gateway
            initialDelaySeconds: 20
            periodSeconds: 5
---
```

Makes it possible to solve issues like https://github.com/zeebe-io/zeebe/issues/4524, where I want to update the thread count of the gateway.