### PR TITLE
Allow custom annotations on the gateway Deployment pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This functionality is in beta and is subject to change. The design and code is l
 | `gateway.replicas`         | The number of standalone gateways that should be deployed | `1`
 | `gateway.logLevel`         | The log level of the gateway, one of: ERROR, WARN, INFO, DEBUG, TRACE | `warn`
 | `gateway.env`         |  Pass additional environment variables to the Zeebe broker pods; <br> variables should be specified using standard Kubernetes raw YAML format. See below for an example.| `[]`
+| `gateway.podAnnotations`         | Annotations to be applied to the gateway Deployment pod template | ``
 | `serviceHttpPort`         | The http port used by the brokers and the gateway| `9600`
 | `serviceGatewayPort`         | The gateway port used by the gateway | `26500`
 | `serviceInternalPort`         | The internal port used by the brokers and the gateway | `26502`

--- a/zeebe-cluster/templates/gateway-deployment.yaml
+++ b/zeebe-cluster/templates/gateway-deployment.yaml
@@ -21,6 +21,10 @@ spec:
         app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app: {{ printf "%s-gateway" (tpl .Values.global.zeebe .) | quote }}
+      annotations:
+        {{- range $key, $value := .Values.gateway.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       containers:
         - name: {{ .Chart.Name }}-gateway


### PR DESCRIPTION
Adds support for custom annotations on the pods of the gateway's Deployment via a new value `gateway.podAnnotations`. This follows the existing pattern of the other custom annotation blocks.

Closes #65 