### PR TITLE
chore: bump default zeebe version

### DIFF
--- a/zeebe-cluster/values.yaml
+++ b/zeebe-cluster/values.yaml
@@ -10,7 +10,7 @@ global:
 
 image:
   repository: camunda/zeebe
-  tag: 0.23.2
+  tag: 0.23.3
   pullPolicy: IfNotPresent
 
 clusterSize: "3"


### PR DESCRIPTION
This PR simply bumps the release version to the latest Zeebe version :slightly_smiling_face: 