### PR TITLE
chore: standardizes labels

### DIFF
--- a/zeebe-cluster/Chart.yaml
+++ b/zeebe-cluster/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "0.23.3"
 description: Zeebe Cluster Helm Chart for Kubernetes
 name: zeebe-cluster
 version: 0.1.0-SNAPSHOT

--- a/zeebe-cluster/templates/_helpers.tpl
+++ b/zeebe-cluster/templates/_helpers.tpl
@@ -62,9 +62,17 @@ app.kubernetes.io/component: gateway
 Common names
 */}}
 {{- define "zeebe-cluster.names.broker" -}}
-{{- tpl .Values.global.zeebe . | quote -}}
+{{- if .Values.global.zeebe -}}
+{{- tpl .Values.global.zeebe . | trunc 63 | trimSuffix "-" | quote -}}
+{{- else -}}
+{{- printf "%s-broker" .Release.Name | trunc 63 | trimSuffix "-" | quote -}}
+{{- end -}}
 {{- end -}}
 
+{{/*
+Creates a valid DNS name for the gateway
+*/}}
 {{- define "zeebe-cluster.names.gateway" -}}
-{{- printf "%s-gateway" (tpl "zeebe-cluster.name" .) | quote -}}
+{{- $name := default .Release.Name (tpl .Values.global.zeebe .) -}}
+{{- printf "%s-gateway" $name | trunc 63 | trimSuffix "-" | quote -}}
 {{- end -}}

--- a/zeebe-cluster/templates/_helpers.tpl
+++ b/zeebe-cluster/templates/_helpers.tpl
@@ -36,8 +36,8 @@ Common labels
 */}}
 {{- define "zeebe-cluster.labels" -}}
 app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
-helm.sh/chart: {{ include "zeebe-cluster.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+helm.sh/chart: {{ include "zeebe-cluster.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -46,4 +46,25 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 
 {{- define "zeebe-cluster.version" -}}
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+
+{{- define "zeebe-cluster.labels.broker" -}}
+{{- template "zeebe-cluster.labels" . }}
+app.kubernetes.io/component: broker
+{{- end -}}
+
+{{- define "zeebe-cluster.labels.gateway" -}}
+{{- template "zeebe-cluster.labels" . }}
+app.kubernetes.io/component: gateway
+{{- end -}}
+
+{{/*
+Common names
+*/}}
+{{- define "zeebe-cluster.names.broker" -}}
+{{- tpl .Values.global.zeebe . | quote -}}
+{{- end -}}
+
+{{- define "zeebe-cluster.names.gateway" -}}
+{{- printf "%s-gateway" (tpl "zeebe-cluster.name" .) | quote -}}
 {{- end -}}

--- a/zeebe-cluster/templates/configmap.yaml
+++ b/zeebe-cluster/templates/configmap.yaml
@@ -1,10 +1,8 @@
 kind: ConfigMap
 metadata:
-  name: {{ tpl .Values.global.zeebe . | quote }}
+  name: {{ include "zeebe-cluster.name" . }}
   labels: 
-    app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app: {{ tpl .Values.global.zeebe . | quote }}
+    {{- include "zeebe-cluster.labels" . | nindent 4 }}
 apiVersion: v1
 data:
   startup.sh: |

--- a/zeebe-cluster/templates/configmap.yaml
+++ b/zeebe-cluster/templates/configmap.yaml
@@ -1,6 +1,6 @@
 kind: ConfigMap
 metadata:
-  name: {{ include "zeebe-cluster.name" . }}
+  name: {{ include "zeebe-cluster.fullname" . }}
   labels: 
     {{- include "zeebe-cluster.labels" . | nindent 4 }}
 apiVersion: v1

--- a/zeebe-cluster/templates/gateway-deployment.yaml
+++ b/zeebe-cluster/templates/gateway-deployment.yaml
@@ -5,7 +5,8 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app: {{ printf "%s-gateway" (tpl .Values.global.zeebe .) | quote }}
+    app.kubernetes.io/component: gateway
+    app: {{ tpl .Values.global.zeebe . | quote }}
   annotations:
       {{- range $key, $value := .Values.annotations }}
       {{ $key }}: {{ $value | quote }}

--- a/zeebe-cluster/templates/gateway-deployment.yaml
+++ b/zeebe-cluster/templates/gateway-deployment.yaml
@@ -1,12 +1,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ printf "%s-gateway" (tpl .Values.global.zeebe .) | quote }}
+  name: {{ include "zeebe-cluster.names.gateway" . }}
   labels:
-    app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/component: gateway
-    app: {{ tpl .Values.global.zeebe . | quote }}
+    {{- include "zeebe-cluster.labels.gateway" . | nindent 4 }}
   annotations:
       {{- range $key, $value := .Values.annotations }}
       {{ $key }}: {{ $value | quote }}
@@ -15,20 +12,18 @@ spec:
   replicas: {{ .Values.gateway.replicas  }}
   selector:
     matchLabels:
-      app: {{ printf "%s-gateway" (tpl .Values.global.zeebe .) | quote }}
+      {{- include "zeebe-cluster.labels.gateway" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app: {{ printf "%s-gateway" (tpl .Values.global.zeebe .) | quote }}
+        {{- include "zeebe-cluster.labels.gateway" . | nindent 8 }}
       annotations:
         {{- range $key, $value := .Values.gateway.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
     spec:
       containers:
-        - name: {{ .Chart.Name }}-gateway
+        - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/zeebe-cluster/templates/gateway-poddisruptionbudget.yaml
+++ b/zeebe-cluster/templates/gateway-poddisruptionbudget.yaml
@@ -4,13 +4,11 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ printf "%s-gateway" (tpl .Values.global.zeebe .) | quote }}
   labels:
-    app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app: {{ printf "%s-gateway" (tpl .Values.global.zeebe .) | quote }}
+    {{- include "zeebe-cluster.labels.gateway" . | nindent 4 }}
 spec:
   minAvailable: {{ .Values.gateway.podDisruptionBudget.minAvailable }}
   maxUnavailable: {{ .Values.gateway.podDisruptionBudget.maxUnavailable }}
   selector:
     matchLabels:
-      app: {{ printf "%s-gateway" (tpl .Values.global.zeebe .) | quote }}
+      {{- include "zeebe-cluster.labels.gateway" . | nindent 6 }}
 {{ end }}

--- a/zeebe-cluster/templates/gateway-service.yaml
+++ b/zeebe-cluster/templates/gateway-service.yaml
@@ -1,19 +1,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-gateway" (tpl .Values.global.zeebe .) | quote }}
+  name: {{ include "zeebe-cluster.names.gateway" . }}
   labels:
-    app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app: {{ tpl .Values.global.zeebe . | quote }}
+    {{- include "zeebe-cluster.labels.gateway" . | nindent 4 }}
   annotations:
-{{- toYaml  .Values.annotations | nindent 4 }}   
+    {{- toYaml  .Values.annotations | nindent 4 }}
 spec:
   selector:
-    app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/component: gateway
-    app: {{ tpl .Values.global.zeebe . | quote }}
+    {{- include "zeebe-cluster.labels.gateway" . | nindent 6 }}
   ports:
     - port: {{ .Values.serviceHttpPort }}
       protocol: TCP

--- a/zeebe-cluster/templates/gateway-service.yaml
+++ b/zeebe-cluster/templates/gateway-service.yaml
@@ -5,12 +5,15 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app: {{ tpl .Values.global.zeebe . }}-gateway
+    app: {{ tpl .Values.global.zeebe . | quote }}
   annotations:
 {{- toYaml  .Values.annotations | nindent 4 }}   
 spec:
   selector:
-    app: {{ tpl .Values.global.zeebe . }}-gateway 
+    app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: gateway
+    app: {{ tpl .Values.global.zeebe . | quote }}
   ports:
     - port: {{ .Values.serviceHttpPort }}
       protocol: TCP

--- a/zeebe-cluster/templates/poddisruptionbudget.yaml
+++ b/zeebe-cluster/templates/poddisruptionbudget.yaml
@@ -2,17 +2,13 @@
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ tpl .Values.global.zeebe . | quote }}
+  name: {{ include "zeebe-cluster.names.broker" . }}
   labels:
-    app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app: {{ tpl .Values.global.zeebe . | quote }}
+    {{- include "zeebe-cluster.labels.broker" . | nindent 4 }}
 spec:
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
-      app: {{ tpl .Values.global.zeebe . | quote }}
+      {{- include "zeebe-cluster.labels.broker" . | nindent 6 }}
 {{ end }}

--- a/zeebe-cluster/templates/service-monitor.yaml
+++ b/zeebe-cluster/templates/service-monitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "zeebe-cluster.name" . }}
+  name: {{ include "zeebe-cluster.fullname" . }}
   labels:
     {{- include "zeebe-cluster.labels" . | nindent 4 }}
     release: metrics

--- a/zeebe-cluster/templates/service-monitor.yaml
+++ b/zeebe-cluster/templates/service-monitor.yaml
@@ -2,15 +2,16 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: zeebe-monitor
+  name: {{ include "zeebe-cluster.name" . }}
   labels:
-      release: metrics
+    {{- include "zeebe-cluster.labels" . | nindent 4 }}
+    release: metrics
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
+      {{- include "zeebe-cluster.labels" . | nindent 6 }}
   endpoints:
-      - honorLabels: true
-        port: http
-        interval: 10s
+    - honorLabels: true
+      port: http
+      interval: 10s
 {{- end }}

--- a/zeebe-cluster/templates/service-monitor.yaml
+++ b/zeebe-cluster/templates/service-monitor.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: zeebe
+      app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
   endpoints:
       - honorLabels: true
         port: http

--- a/zeebe-cluster/templates/service.yaml
+++ b/zeebe-cluster/templates/service.yaml
@@ -1,15 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ tpl .Values.global.zeebe . | quote }}
+  name: {{ include "zeebe-cluster.names.broker" . }}
   labels:
-    app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/component: broker
-    app: {{ tpl .Values.global.zeebe . | quote }}
-{{- toYaml  .Values.labels | nindent 4 }}
+    {{- include "zeebe-cluster.labels.broker" . | nindent 4 }}
+    {{- toYaml  .Values.labels | nindent 4 }}
   annotations:
-{{- toYaml  .Values.annotations | nindent 4 }}    
+    {{- toYaml  .Values.annotations | nindent 4 }}    
 spec:
   clusterIP: None
   publishNotReadyAddresses: true
@@ -25,7 +22,4 @@ spec:
       protocol: TCP
       name: {{ default "command" .Values.serviceCommandName }}
   selector:
-    app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/component: broker
-    app: {{ tpl .Values.global.zeebe . | quote }}
+    {{- include "zeebe-cluster.labels.broker" . | nindent 4 }}

--- a/zeebe-cluster/templates/service.yaml
+++ b/zeebe-cluster/templates/service.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: broker
     app: {{ tpl .Values.global.zeebe . | quote }}
 {{- toYaml  .Values.labels | nindent 4 }}
   annotations:
@@ -26,4 +27,5 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: broker
     app: {{ tpl .Values.global.zeebe . | quote }}

--- a/zeebe-cluster/templates/statefulset.yaml
+++ b/zeebe-cluster/templates/statefulset.yaml
@@ -37,7 +37,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: ZEEBE_BROKER_CLUSTER_CLUSTERNAME
-          value: {{ tpl .Values.global.zeebe . }}    
+          value: {{ tpl .Values.global.zeebe . }}
         - name: ZEEBE_LOG_LEVEL
           value: debug
         - name: ZEEBE_BROKER_CLUSTER_PARTITIONSCOUNT
@@ -103,7 +103,7 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: {{ tpl .Values.global.zeebe . | quote }}
+          name: {{ include "zeebe-cluster.fullname" . }}
           defaultMode: 0744
       - name: exporters
         emptyDir: {}    

--- a/zeebe-cluster/templates/statefulset.yaml
+++ b/zeebe-cluster/templates/statefulset.yaml
@@ -1,13 +1,10 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ tpl .Values.global.zeebe . | quote }}
+  name: {{ include "zeebe-cluster.names.broker" . }}
   labels:
-    app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/component: broker
-    app: {{ tpl .Values.global.zeebe . | quote }}
-{{- toYaml  .Values.labels | nindent 4 }}
+    {{- include "zeebe-cluster.labels.broker" . | nindent 4 }}
+    {{- toYaml  .Values.labels | nindent 4 }}
   annotations:
     {{- range $key, $value := .Values.annotations }}
     {{ $key }}: {{ $value | quote }}
@@ -16,21 +13,15 @@ spec:
   replicas: {{ .Values.clusterSize  }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/component: broker
-      app: {{ tpl .Values.global.zeebe . | quote }}
-  serviceName: {{ tpl .Values.global.zeebe . | quote }}
+      {{- include "zeebe-cluster.labels.broker" . | nindent 6 }}
+  serviceName: {{ include "zeebe-cluster.names.broker" . }}
   updateStrategy:
     type: RollingUpdate
   podManagementPolicy: Parallel
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/component: broker
-        app: {{ tpl .Values.global.zeebe . | quote }}
+        {{- include "zeebe-cluster.labels.broker" . | nindent 8 }}
       annotations:
         {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}

--- a/zeebe-cluster/templates/statefulset.yaml
+++ b/zeebe-cluster/templates/statefulset.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: broker
     app: {{ tpl .Values.global.zeebe . | quote }}
 {{- toYaml  .Values.labels | nindent 4 }}
   annotations:
@@ -17,6 +18,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: broker
       app: {{ tpl .Values.global.zeebe . | quote }}
   serviceName: {{ tpl .Values.global.zeebe . | quote }}
   updateStrategy:
@@ -27,6 +29,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: broker
         app: {{ tpl .Values.global.zeebe . | quote }}
       annotations:
         {{- range $key, $value := .Values.podAnnotations }}


### PR DESCRIPTION
This PR attempts to standardize our use of labels to a set of well known labels taken from Kubernetes and Helm. All components will have the following common labels:

```yaml
app.kubernetes.io/instance=<RELEASE NAME>
app.kubernetes.io/managed-by=Helm
app.kubernetes.io/name=<CHART NAME>
app.kubernetes.io/version=<APP VERSION>
helm.sh/chart=zeebe-cluster-<CHART VERSION>
```

Additionally, the gateway and the broker will have an `app.kubernetes.io/component=<broker|gateway>` labels, which is applied to all resources pertaining to either.

The PR also standardizes the names of the `ConfigMap` and the `ServiceMonitor` by using the pre-generated `zeebe-cluster.fullname` template which ensures that the given name is compliant with Kubernetes rules about names, and uses a combination of the chart and release name (but can be overriden with `.Values.fullnameOverride`).

I based this off Helm docs and different charts, let me know what you guys think - I think in some aspect this could be considered a breaking change as well, so happy to discuss this.