### PR TITLE
chore(values): remove gc settings

### DIFF
--- a/zeebe-cluster/values.yaml
+++ b/zeebe-cluster/values.yaml
@@ -45,18 +45,12 @@ prometheus:
     enabled: false
 
 JavaOpts: >-
-  -XX:+UseParallelGC
-  -XX:MinHeapFreeRatio=5
-  -XX:MaxHeapFreeRatio=10
-  -XX:MaxRAMPercentage=25.0
-  -XX:GCTimeRatio=4
-  -XX:AdaptiveSizePolicyWeight=90
-  -XX:+PrintFlagsFinal
   -Xmx4g
   -Xms4g
   -XX:+HeapDumpOnOutOfMemoryError
   -XX:HeapDumpPath=/usr/local/zeebe/data
   -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log
+  -XX:+ExitOnOutOfMemoryError
 
 labels:
   app: zeebe    


### PR DESCRIPTION
Removes the current GC settings as described here https://github.com/zeebe-io/zeebe/issues/4664#issuecomment-646529238

It also removes the PrintFinalFlags, since I see no value in them. It just more annoying then useful, especially if you use jps, jcmd or any other java tool. If you want to see the flag you can run on the pod jcmd <pid> VM.flags -all

Adds `ExitOnOutOfMemoryError` as described here https://github.com/zeebe-io/zeebe-cluster-helm/issues/80#issuecomment-646008695

closes https://github.com/zeebe-io/zeebe-cluster-helm/issues/80