### PR TITLE
Make JVM memory limit dynamic by setting -XX:MaxRAMPercentage

### DIFF
--- a/zeebe-cluster/values.yaml
+++ b/zeebe-cluster/values.yaml
@@ -45,8 +45,7 @@ prometheus:
     enabled: false
 
 JavaOpts: >-
-  -Xmx4g
-  -Xms4g
+  -XX:MaxRAMPercentage=50.0
   -XX:+HeapDumpOnOutOfMemoryError
   -XX:HeapDumpPath=/usr/local/zeebe/data
   -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log

--- a/zeebe-cluster/values.yaml
+++ b/zeebe-cluster/values.yaml
@@ -45,7 +45,7 @@ prometheus:
     enabled: false
 
 JavaOpts: >-
-  -XX:MaxRAMPercentage=50.0
+  -XX:MaxRAMPercentage=25.0
   -XX:+HeapDumpOnOutOfMemoryError
   -XX:HeapDumpPath=/usr/local/zeebe/data
   -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log


### PR DESCRIPTION
The JVM memory limit set by #80/#81 seems a little too stiff to me as people might assign more or less memory to their pods:

>  -Xmx4g
>   -Xms4g

I suggest working with `-XX:MaxRAMPercentage` which has been introduced by Java 10 specifically for container support. 25 or 50 percent for the JVM heap should leave enough memory available for Rocks DB.

Multiple recent sources seem to confirm this direction:

- [Java in a Container: Resource Allocation Guidelines (October 31, 2019)](https://www.ccampo.me/java/docker/containers/kubernetes/2019/10/31/java-in-a-container.html)
- [Playing with the JVM inside Docker Containers (December 3, 2019)](https://blog.nebrass.fr/playing-with-the-jvm-inside-docker-containers/)
- [JVM Memory Settings in a Container Environment (Nov 10, 2018; **partly out-of-date but with some updates on Java 10+**)](https://medium.com/adorsys/jvm-memory-settings-in-a-container-environment-64b0840e1d9e)

The first source above even says: "By default, the JVM heap gets 25% of the container’s memory." So knowing that Java itself need more than heap, e.g. for each thread's stack, and RocksDB needs a lot of memory, we might even leave it a 25% or lower.

What do you think?