### PR TITLE
chore: fix gateway config volume name

### DIFF
--- a/zeebe-cluster/templates/gateway-deployment.yaml
+++ b/zeebe-cluster/templates/gateway-deployment.yaml
@@ -81,5 +81,5 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: {{ tpl .Values.global.zeebe . | quote }}
+            name: {{ include "zeebe-cluster.fullname" . }}
             defaultMode: 0744


### PR DESCRIPTION
I introduced a bug changing the config map name where the gateway doesn't come up because it had the wrong volume name.

This fixes it - I tested it now deploying a new snapshot benchmark :slightly_smiling_face: 