### PR TITLE
fix: remove transient labels

### DIFF
--- a/zeebe-cluster/templates/_helpers.tpl
+++ b/zeebe-cluster/templates/_helpers.tpl
@@ -37,10 +37,6 @@ Common labels
 {{- define "zeebe-cluster.labels" -}}
 app.kubernetes.io/name: {{ include "zeebe-cluster.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-helm.sh/chart: {{ include "zeebe-cluster.chart" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 


### PR DESCRIPTION
This PR removes mutable information from labels to allow users to upgrade chart/Zeebe versions without having to tear down their previous installations.

Note that this was minimally tested via a single upgrade - happy to hear any other advice there.

EDIT: see https://github.com/zeebe-io/zeebe-cluster-helm/pull/79#issuecomment-662499495 for more