### PR TITLE
feat(gateway): Add ability to set gateway resource limits

### DIFF
--- a/zeebe-cluster/templates/gateway-deployment.yaml
+++ b/zeebe-cluster/templates/gateway-deployment.yaml
@@ -78,6 +78,10 @@ spec:
               port: {{ default "gateway" .Values.serviceGatewayName  }}
             initialDelaySeconds: 20
             periodSeconds: 5
+          {{- if .Values.gateway.resources}}
+          resources:
+            {{- toYaml .Values.gateway.resources | nindent 12 }}
+          {{- end }}
       volumes:
         - name: config
           configMap:

--- a/zeebe-cluster/values.yaml
+++ b/zeebe-cluster/values.yaml
@@ -31,6 +31,7 @@ gateway:
     enabled: false
     minAvailable: 1
     maxUnavailable:
+  resources:  {}
 
 elasticsearch:
   enabled: true


### PR DESCRIPTION
Allow optional configuration for the gateway pod resource limits. Follows the same pattern as the broker statefulset.

Example configuration:
```
gateway:
  resources:
    requests:
      cpu: 200m
      memory: 1Gi
```

Fixes #74. 