### PR TITLE
feat(broker): Add ability to disable elasticsearch exporter

### DIFF
--- a/zeebe-cluster/templates/statefulset.yaml
+++ b/zeebe-cluster/templates/statefulset.yaml
@@ -52,7 +52,7 @@ spec:
           value: {{ .Values.ioThreadCount  | quote }}
         - name: ZEEBE_BROKER_GATEWAY_ENABLE
           value: "false"
-        {{- if .Values.global.elasticsearch.exporter }}
+        {{- if not .Values.global.elasticsearch.disableExporter }}
         - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME
           value: "io.zeebe.exporter.ElasticsearchExporter"
         - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL

--- a/zeebe-cluster/templates/statefulset.yaml
+++ b/zeebe-cluster/templates/statefulset.yaml
@@ -52,10 +52,12 @@ spec:
           value: {{ .Values.ioThreadCount  | quote }}
         - name: ZEEBE_BROKER_GATEWAY_ENABLE
           value: "false"
+        {{- if .Values.global.elasticsearch.exporter }}
         - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME
           value: "io.zeebe.exporter.ElasticsearchExporter"
         - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL
           value: "http://{{ .Values.global.elasticsearch.host }}:{{ .Values.global.elasticsearch.port }}"
+        {{- end }}
         - name: ZEEBE_BROKER_NETWORK_COMMANDAPI_PORT
           value: {{ .Values.serviceCommandPort  | quote }}
         - name: ZEEBE_BROKER_NETWORK_INTERNALAPI_PORT

--- a/zeebe-cluster/values.yaml
+++ b/zeebe-cluster/values.yaml
@@ -4,6 +4,7 @@
 
 global: 
   elasticsearch:
+    exporter: true
     host: "elasticsearch-master"
     port: 9200 
   zeebe: "{{ .Release.Name }}-zeebe"

--- a/zeebe-cluster/values.yaml
+++ b/zeebe-cluster/values.yaml
@@ -4,7 +4,6 @@
 
 global: 
   elasticsearch:
-    exporter: true
     host: "elasticsearch-master"
     port: 9200 
   zeebe: "{{ .Release.Name }}-zeebe"


### PR DESCRIPTION
Adds a toggle that can be used to disable the Elasticsearch exporter. Defaults to enabled for backwards compatibility.