### PR TITLE
fix(broker): Fix the loglevel value reference for broker statefulset

### DIFF
--- a/zeebe-cluster/templates/statefulset.yaml
+++ b/zeebe-cluster/templates/statefulset.yaml
@@ -39,7 +39,7 @@ spec:
         - name: ZEEBE_BROKER_CLUSTER_CLUSTERNAME
           value: {{ tpl .Values.global.zeebe . }}
         - name: ZEEBE_LOG_LEVEL
-          value: {{ .Values.global.logLevel | quote }}
+          value: {{ .Values.logLevel | quote }}
         - name: ZEEBE_BROKER_CLUSTER_PARTITIONSCOUNT
           value: {{ .Values.partitionCount | quote }}
         - name: ZEEBE_BROKER_CLUSTER_CLUSTERSIZE


### PR DESCRIPTION
Updates the statefulset reference to reference the default in values.yaml. 

Alternatively, the values.yaml file could be updated to move logLevel underneath global, but the root-level placement matches other broker configuration.

Without this change, the default settings generate this environment variable in the broker statefulset:
```
         - name: ZEEBE_LOG_LEVEL
           value: 
```
and the broker displays the following error:
```
WARN Error while converting string [] to type [class org.apache.logging.log4j.Level]. Using default value [null]. java.lang.IllegalArgumentException: Unknown level constant [].
```