### PR TITLE
feat(gateway): Enable setting nodeSelector / affinity / tolerations on gateway deployment

### DIFF
--- a/zeebe-cluster/templates/gateway-deployment.yaml
+++ b/zeebe-cluster/templates/gateway-deployment.yaml
@@ -87,3 +87,15 @@ spec:
           configMap:
             name: {{ include "zeebe-cluster.fullname" . }}
             defaultMode: 0744
+{{- with .Values.gateway.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.gateway.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.gateway.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}


### PR DESCRIPTION
Allows users to customize nodeSelector / affinity / toleration settings on the gateway pods. Copied from the statefulset template.