### PR TITLE
Fixes #104 by updating the chart dependency from prometheus to kube-prometheus-stack

### DIFF
--- a/charts/zeebe-cluster-helm/Chart.yaml
+++ b/charts/zeebe-cluster-helm/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
   repository: "https://helm.elastic.co" 
   version: 7.5.1
   condition: "kibana.enabled"
-- name: prometheus
+- name: kube-prometheus-stack
   repository: "https://prometheus-community.github.io/helm-charts"
-  version: 12.0.1
+  version: 12.0.X
   condition: "prometheus.enabled"


### PR DESCRIPTION
Fixes #104 by updating the chart dependency from prometheus to kube-prometheus-stack which is the new name for the old prometheus-operator chart. Also updated the version to use the latest 12.0.X version