### PR TITLE
Version management fix

### DIFF
--- a/charts/zeebe-cluster-helm/Chart.yaml
+++ b/charts/zeebe-cluster-helm/Chart.yaml
@@ -1,9 +1,8 @@
 apiVersion: v2
-appVersion: "0.25.0"
 description: Zeebe Cluster Helm Chart for Kubernetes
 name: zeebe-cluster-helm
 type: application
-version: 0.1.0-SNAPSHOT
+version: 0.26.1
 icon: https://zeebe.io/img/zeebe-logo.png
 dependencies:
 - name: elasticsearch


### PR DESCRIPTION
When using Helm charts, one should bump the version and/or appVersion if something inside changes. Recently, the image tag inside the chart was updated to 0.26.1 without any version bump on chart level. This makes it impossible for systems using these charts to detect changes and notify about an update and/or take automated actions.

Given that the appVersion field is optional, this PR gets rid of it and simply changes the chart `version` field to reflect the image of Zeebe. Alternatively, one could keep the chart `version` at `0.1.0-SNAPSHOT` and change the `appVersion` to 0.26.1

If the latter would be preferred, let me know in a comment and I'll be happy to create another PR.

More info about best practices: https://codefresh.io/docs/docs/new-helm/helm-best-practices/